### PR TITLE
Copy TypeScript declaration files into dist folder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [12.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
 
     steps:
       - id: setup-node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 0.3.1 - 2020-09-08
+
+### Fixed
+
+- Copy local TypeScript module declarations into `dist`
+
 ## 0.3.0 - 2020-09-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "type-check": "tsc",
     "test": "jest",
     "test:ci": "yarn lint && yarn type-check && yarn test",
-    "build": "tsc -p tsconfig.dist.json --declaration",
+    "build": "tsc -p tsconfig.dist.json --declaration && cp -R ./src/types dist",
     "prepush": "yarn lint && yarn type-check && jest --changedSince master",
     "prepack": "yarn build"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-whois",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A JupiterOne managed integration for WHOIS data",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/DomainProviderClient.ts
+++ b/src/DomainProviderClient.ts
@@ -1,5 +1,7 @@
-import { retry } from '@lifeomic/attempt';
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="./types/whois-api" />
 import whois, { WhoisLookupDomain } from 'whois-api';
+import { retry } from '@lifeomic/attempt';
 import { IntegrationLogger } from '@jupiterone/integration-sdk-core';
 import pMap from 'p-map';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="./types/is-valid-domain" />
+import isValidDomain from 'is-valid-domain';
 import {
   IntegrationInvocationConfig,
   IntegrationConfigLoadError,
@@ -9,7 +12,6 @@ import {
   createIntegrationEntity,
   getTime,
 } from '@jupiterone/integration-sdk-core';
-import isValidDomain from 'is-valid-domain';
 
 export const ENTITY_DOMAIN_CLASS = 'Domain';
 export const ENTITY_DOMAIN_TYPE = 'internet_domain';


### PR DESCRIPTION
Not copying of the local module declarations is causing TypeScript compilation issues in the deployment project.